### PR TITLE
Allow defining a function to create the overrides table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ To configure the plugin, you can call `require('ayu').setup(values)`, where `val
 ```lua
 require('ayu').setup({
     mirage = false, -- Set to `true` to use `mirage` variant instead of `dark` for dark background.
-    overrides = {}, -- A dictionary with a group names associated with a dictionary with parameters (`bg`, `fg`, `sp` and `style`) and colors in hex.
+    overrides = {}, -- A dictionary of group names, each associated with a dictionary of parameters (`bg`, `fg`, `sp` and `style`) and colors in hex.
 })
 ```
+
+Alternatively, `overrides` can be a function that returns a dictionary of the same format. You can use the function to override based on a dynamic condition, such as the value of `&background`.
 
 Colorscheme also provides a theme for [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim). You can set in `setup` lualine:
 
@@ -35,9 +37,9 @@ require('lualine').setup({
 })
 ```
 
-### Overrides example
+### `overrides` Examples
 
-Replace `IncSearch` group with foreground set to `#FFFFFF`:
+1. Replace `IncSearch` group with foreground set to `#FFFFFF`:
 
 ```lua
 require('ayu').setup({
@@ -45,6 +47,20 @@ require('ayu').setup({
     IncSearch = { fg = '#FFFFFF' }
   }
 })
+```
+
+2. Change the background color of non-active windows to make the active one more obvious, specifying overrides for both light and dark backgrounds:
+
+```lua
+require 'ayu'.setup({
+  overrides = function()
+    return vim.o.background == 'dark' and
+          { NormalNC = {bg = '#0f151e', fg = '#808080'} }
+          or
+          { NormalNC = {bg = '#f0f0f0', fg = '#808080'} }
+  end
+})
+
 ```
 
 **Tip:** You can use `:source $VIMRUNTIME/syntax/hitest.vim` to see all highlighting groups.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A colorscheme for Neovim 0.7+ reimplemented in lua from [ayu-vim](https://github
 
 ## Commands
 
-To apply the colorscheme, you can call `require('ayu').colorscheme()` from lua or use `:colorscheme ayu` command. By default it respect your `background` (see `:h background`) setting to choose between `dark` and `light` variants. But you can use `:colorscheme ayu-<dark,light,mirage>]` commands to apply a variant directly.
+To apply the colorscheme, you can call `require('ayu').colorscheme()` from lua or use `:colorscheme ayu` command. By default it respects your `'background'` (see `:h background`) setting to choose between `dark` and `light` variants. But you can use the `:colorscheme ayu-dark`, `:colorscheme ayu-light`, or `:colorscheme ayu-mirage` commands to apply a variant directly.
 
 ## Configuration
 
@@ -25,7 +25,7 @@ require('ayu').setup({
 })
 ```
 
-Alternatively, `overrides` can be a function that returns a dictionary of the same format. You can use the function to override based on a dynamic condition, such as the value of `&background`.
+Alternatively, `overrides` can be a function that returns a dictionary of the same format. You can use the function to override based on a dynamic condition, such as the value of `'background'`.
 
 Colorscheme also provides a theme for [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim). You can set in `setup` lualine:
 
@@ -54,10 +54,11 @@ require('ayu').setup({
 ```lua
 require 'ayu'.setup({
   overrides = function()
-    return vim.o.background == 'dark' and
-          { NormalNC = {bg = '#0f151e', fg = '#808080'} }
-          or
-          { NormalNC = {bg = '#f0f0f0', fg = '#808080'} }
+    if vim.o.background == 'dark' then
+      return { NormalNC = {bg = '#0f151e', fg = '#808080'} }
+    else
+      return { NormalNC = {bg = '#f0f0f0', fg = '#808080'} }
+    end
   end
 })
 
@@ -65,7 +66,7 @@ require 'ayu'.setup({
 
 **Tip:** You can use `:source $VIMRUNTIME/syntax/hitest.vim` to see all highlighting groups.
 
-To get the colors from the colorscheme you can use `ayu.colors`. Example:
+3. To get the colors from the colorscheme you can use `ayu.colors`:
 
 ```lua
 local colors = require('ayu.colors')

--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -231,7 +231,7 @@ local function set_groups()
     VM_Mono = { fg = colors.bg, bg = colors.comment },
   }
 
-  groups = vim.tbl_extend('force', groups, config.overrides)
+    groups = vim.tbl_extend('force', groups, type(config.overrides) == "function" and config.overrides() or config.overrides)
 
   for group, parameters in pairs(groups) do
     vim.api.nvim_set_hl(0, group, parameters)

--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -231,7 +231,7 @@ local function set_groups()
     VM_Mono = { fg = colors.bg, bg = colors.comment },
   }
 
-    groups = vim.tbl_extend('force', groups, type(config.overrides) == "function" and config.overrides() or config.overrides)
+  groups = vim.tbl_extend('force', groups, type(config.overrides) == 'function' and config.overrides() or config.overrides)
 
   for group, parameters in pairs(groups) do
     vim.api.nvim_set_hl(0, group, parameters)


### PR DESCRIPTION
This PR came about because I sometimes switch between light and dark backgrounds, while also having overridden some highlight groups. The former capabilities allowed there to be only one set of overrides. This PR adds the ability to define a function that will run each time the `'background'` setting changes. Using an appropriate `if` statement then returns the necessary table of highlight groups. In actuality, any logic can be used in the function, as long at it returns something that can be used by `require 'ayu'.colorscheme()`.