### PR TITLE
Set different color for parameters

### DIFF
--- a/lua/ayu/colors.lua
+++ b/lua/ayu/colors.lua
@@ -25,7 +25,7 @@ function colors.generate(mirage)
       colors.constant = '#D4BFFF'
       colors.operator = '#F29E74'
       colors.error = '#FF3333'
-      colors.parameter = '#D3B8F9'
+      colors.lsp_parameter = '#D3B8F9'
 
       colors.line = '#191E2A'
       colors.panel_bg = '#232834'
@@ -66,7 +66,7 @@ function colors.generate(mirage)
       colors.constant = '#FFEE99'
       colors.operator = '#F29668'
       colors.error = '#FF3333'
-      colors.parameter = '#CB9FF8'
+      colors.lsp_parameter = '#CB9FF8'
 
       colors.line = '#00010A'
       colors.panel_bg = '#0D1016'
@@ -108,7 +108,7 @@ function colors.generate(mirage)
     colors.constant = '#A37ACC'
     colors.operator = '#ED9366'
     colors.error = '#F51818'
-    colors.parameter = '#C788CE'
+    colors.lsp_parameter = '#C788CE'
 
     colors.line = '#EFF0F1'
     colors.panel_bg = '#FFFFFF'

--- a/lua/ayu/colors.lua
+++ b/lua/ayu/colors.lua
@@ -25,6 +25,7 @@ function colors.generate(mirage)
       colors.constant = '#D4BFFF'
       colors.operator = '#F29E74'
       colors.error = '#FF3333'
+      colors.parameter = '#D3B8F9'
 
       colors.line = '#191E2A'
       colors.panel_bg = '#232834'
@@ -65,6 +66,7 @@ function colors.generate(mirage)
       colors.constant = '#FFEE99'
       colors.operator = '#F29668'
       colors.error = '#FF3333'
+      colors.parameter = '#CB9FF8'
 
       colors.line = '#00010A'
       colors.panel_bg = '#0D1016'
@@ -106,6 +108,7 @@ function colors.generate(mirage)
     colors.constant = '#A37ACC'
     colors.operator = '#ED9366'
     colors.error = '#F51818'
+    colors.parameter = '#C788CE'
 
     colors.line = '#EFF0F1'
     colors.panel_bg = '#FFFFFF'

--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -117,7 +117,7 @@ local function set_groups()
     -- TreeSitter.
     ['@property'] = { fg = colors.tag },
     ['@field'] = { fg = colors.tag },
-    ['@parameter'] = { fg = colors.fg },
+    ['@parameter'] = { fg = colors.parameter },
     ['@namespace'] = { fg = colors.func },
     ['@variable.builtin'] = { fg = colors.func },
     ['@text.title'] = { fg = colors.keyword },

--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -117,7 +117,7 @@ local function set_groups()
     -- TreeSitter.
     ['@property'] = { fg = colors.tag },
     ['@field'] = { fg = colors.tag },
-    ['@parameter'] = { fg = colors.parameter },
+    ['@parameter'] = { fg = colors.fg },
     ['@namespace'] = { fg = colors.func },
     ['@variable.builtin'] = { fg = colors.func },
     ['@text.title'] = { fg = colors.keyword },
@@ -134,7 +134,7 @@ local function set_groups()
     ['@lsp.type.enum'] = { link = '@type' },
     ['@lsp.type.interface'] = { link = '@type' },
     ['@lsp.type.struct'] = { link = '@structure' },
-    ['@lsp.type.parameter'] = { link = '@parameter' },
+    ['@lsp.type.parameter'] = { fg = colors.lsp_parameter},
     ['@lsp.type.field'] = { link = '@field' },
     ['@lsp.type.variable'] = { link = '@variable' },
     ['@lsp.type.property'] = { link = '@property' },

--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -134,7 +134,7 @@ local function set_groups()
     ['@lsp.type.enum'] = { link = '@type' },
     ['@lsp.type.interface'] = { link = '@type' },
     ['@lsp.type.struct'] = { link = '@structure' },
-    ['@lsp.type.parameter'] = { fg = colors.lsp_parameter},
+    ['@lsp.type.parameter'] = { fg = colors.lsp_parameter },
     ['@lsp.type.field'] = { link = '@field' },
     ['@lsp.type.variable'] = { link = '@variable' },
     ['@lsp.type.property'] = { link = '@property' },


### PR DESCRIPTION
Sets a different color for the parameters, taking advantage of semantic token highlighting.
Colors where picked from https://github.com/ayu-theme/vscode-ayu

Before ayu-mirage look:
![ayu-mirage-standard](https://user-images.githubusercontent.com/7985687/231619494-218331c4-dcb8-402a-a3a6-e8118c4bed94.png)
After ayu-mirage look:
![ayu-mirage-modified](https://user-images.githubusercontent.com/7985687/231619520-1d279439-2c74-4322-821c-fe2eaf02bc14.png)
After ayu-dark look:
![ayu-dark-modified](https://user-images.githubusercontent.com/7985687/231619559-afe79ed0-e4d5-4b68-8859-027ff691ab80.png)
After ayu-light look:
![ayu-light-modified](https://user-images.githubusercontent.com/7985687/231619574-94c1202f-3630-402b-81e0-909856402d9f.png)

Comparison to vscode ayu-mirage:
![ayu-mirage-vscode](https://user-images.githubusercontent.com/7985687/231619648-67e6f042-ea36-4e77-8497-18daac538cbf.png)

This is probably subjective, but I do think it looks quite nice. Also useful to have parameters in a different highlight within your function.
