### PR TITLE
Add support for `nvim-treesitter-context`

### DIFF
--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -145,6 +145,9 @@ local function set_groups()
     ['@lsp.type.decorator'] = { link = '@function' },
     ['@lsp.mod.constant'] = { link = '@constant' },
 
+    -- TreesitterContext.
+    TreesitterContext = { bg = colors.selection_inactive },
+
     -- Gitsigns.
     GitSignsAddLn = { fg = colors.vcs_added },
     GitSignsDeleteLn = { fg = colors.vcs_removed },
@@ -276,9 +279,6 @@ local function set_groups()
     VM_Cursor = { bg = colors.selection_inactive, sp = colors.fg, underline = true },
     VM_Insert = { sp = colors.fg, underline = true },
     VM_Mono = { fg = colors.bg, bg = colors.comment },
-
-    -- TreesitterContext.
-    TreesitterContext = { bg = colors.selection_inactive },
   }
 
   groups = vim.tbl_extend('force', groups, type(config.overrides) == 'function' and config.overrides() or config.overrides)

--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -276,6 +276,9 @@ local function set_groups()
     VM_Cursor = { bg = colors.selection_inactive, sp = colors.fg, underline = true },
     VM_Insert = { sp = colors.fg, underline = true },
     VM_Mono = { fg = colors.bg, bg = colors.comment },
+
+    -- TreesitterContext.
+    TreesitterContext = { bg = colors.selection_inactive },
   }
 
   groups = vim.tbl_extend('force', groups, type(config.overrides) == 'function' and config.overrides() or config.overrides)


### PR DESCRIPTION
Closes #34 by adding a new entry for the key `TreesitterContext` to the color table.

Tested with the following override configuration:

```lua
  {
    "Shatur/neovim-ayu",
    name = "ayu",
    config = function()
      local ayu = require("ayu")
      local colors = require("ayu.colors")

      local mirage = true
      colors.generate(mirage)

      ayu.setup {
        mirage = mirage,
        overrides = {
          TreesitterContext = {
            bg = colors.selection_inactive,
          },
        },
      }
    end,
  },
```