### PR TITLE
Make the setting of terminal colors optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To configure the plugin, you can call `require('ayu').setup(values)`, where `val
 ```lua
 require('ayu').setup({
     mirage = false, -- Set to `true` to use `mirage` variant instead of `dark` for dark background.
+    terminal = true, -- Set to `false` to let terminal manage its own colors.
     overrides = {}, -- A dictionary of group names, each associated with a dictionary of parameters (`bg`, `fg`, `sp` and `style`) and colors in hex.
 })
 ```

--- a/lua/ayu/config.lua
+++ b/lua/ayu/config.lua
@@ -1,6 +1,7 @@
 local config = {
   defaults = {
     mirage = false,
+    terminal = true,
     overrides = {},
   },
 }

--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -309,7 +309,9 @@ function ayu.colorscheme()
   vim.g.colors_name = 'ayu'
 
   colors.generate(config.mirage)
-  set_terminal_colors()
+  if config.terminal then
+    set_terminal_colors()
+  end
   set_groups()
 end
 


### PR DESCRIPTION
@Shatur , I love this colorscheme, especially for the fact that it has both dark and light variants. I sometimes try out others, but I always come back to **ayu**.  That being said, I've noticed an area that could be improved. When invoking a `:terminal` inside of Neovim, **ayu** sets up some colors that, IMO, don't look so good. The magentas have been lost, and the white isn't bright enough.

This pull request adds an option to disable **ayu**'s setting the `g:terminal_color_n` values. The new default config is shown here. Setting `terminal = false` will let the shell use its original colors, while keeping **ayu** colors in other windows.

```lua
local config = {
  defaults = {
    mirage = false,
    terminal = true,
    overrides = {},
  },
}
```

## Before
![image](https://github.com/Shatur/neovim-ayu/assets/5598066/5f128e14-7f77-4845-9b48-d8810450d2c1)


## After
![image](https://github.com/Shatur/neovim-ayu/assets/5598066/45ccf19c-7b73-4c71-8c4e-c332f6403172)
