### PR TITLE
fix(lualine): add missing modes for `command` and `terminal`

### DIFF
--- a/lua/lualine/themes/ayu.lua
+++ b/lua/lualine/themes/ayu.lua
@@ -23,6 +23,14 @@ local ayu = {
     a = { fg = colors.bg, bg = colors.string, gui = 'bold' },
     b = { fg = colors.string, bg = colors.panel_border },
   },
+  command = {
+    a = { fg = colors.bg, bg = colors.constant, gui = 'bold' },
+    b = { fg = colors.constant, bg = colors.panel_border },
+  },
+  terminal = {
+    a = { fg = colors.bg, bg = colors.string, gui = 'bold' },
+    b = { fg = colors.string, bg = colors.panel_border },
+  },
 }
 
 return ayu


### PR DESCRIPTION
## Add missing `command` and `terminal` mode colors to the ayu lualine theme

When using the `use_mode_colors = true` option for the window/tab components in lualine, the sections `b` and `y` may not display the correct colors due to the absence of color definitions for these modes within the theme script. Resulting in the highlight group, e.g. `lualine_b_command` being initialized with default (cleared) value.

While this issue might be related to how lualine handles highlight groups, the simplest solution is to add the missing mode configurations directly in the theme. 

The `command` mode now uses `colors.constant` (violet), and the `terminal` mode uses the same color of `insert` mode, `colors.string` (green).

---

These screenshots are taken in the mirage theme, but the same applies to all variants.

###### Previous version: (inside terminal mode, shows improper highlights)
![PqRHVRBOOl_1](https://github.com/user-attachments/assets/bf989eab-1246-4b37-a86e-90950aa8fd0d)

###### Command mode:
![PqRHVRBOOl_3](https://github.com/user-attachments/assets/5f90e946-0b66-4bfb-baca-45a6f02abe0d)

###### Terminal mode:
![PqRHVRBOOl_2](https://github.com/user-attachments/assets/15530e7c-81a5-4de9-8ef9-a2f880eb7caa)