### PR TITLE
fix: overrides clears hl groups instead of overwriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ require('lualine').setup({
 require('ayu').setup({
     overrides = {
         Normal = { bg = "None" },
+        NormalFloat = { bg = "none" },
         ColorColumn = { bg = "None" },
         SignColumn = { bg = "None" },
         Folded = { bg = "None" },
         FoldColumn = { bg = "None" },
         CursorLine = { bg = "None" },
         CursorColumn = { bg = "None" },
-        WhichKeyFloat = { bg = "None" },
         VertSplit = { bg = "None" },
     },
 })

--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -325,7 +325,7 @@ local function set_groups()
     MiniTrailspace = { bg = colors.vcs_removed },
   }
 
-  groups = vim.tbl_extend('force', groups, type(config.overrides) == 'function' and config.overrides() or config.overrides)
+  groups = vim.tbl_deep_extend('force', groups, type(config.overrides) == 'function' and config.overrides() or config.overrides)
 
   for group, parameters in pairs(groups) do
     vim.api.nvim_set_hl(0, group, parameters)


### PR DESCRIPTION
Hey there! I found that instead of overwriting, `overrides` rather clears the highlight groups. This should address this issue.