### PR TITLE
add support for `CmpGhostText`

### DIFF
--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -156,6 +156,7 @@ local function set_groups()
     TelescopePromptBorder = { fg = colors.accent },
 
     -- Cmp.
+    CmpGhostText = { fg = colors.comment },
     CmpItemAbbrMatch = { fg = colors.keyword },
     CmpItemAbbrMatchFuzzy = { fg = colors.func },
     CmpItemKindText = { fg = colors.string },


### PR DESCRIPTION
This adds a visual distinction between typed input and possible completion that is used by nvim-cmp/blink.cmp

blink has it's own hl `BlinkCmpGhostText` but uses `CmpGhostText` as fallback (I think), but I it would make more sense to add full blink support in it's own PR.