### PR TITLE
Fix disable-italics-in-comments example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,9 @@ require('ayu').setup({
 #### Disable _italic_ for comments
 
 ```lua
-local colors = require('ayu.colors')
-colors.generate() -- Pass `true` to enable mirage
-
 require('ayu').setup({
-  overrides = function()
-    return { Comment = { fg = colors.comment } }
-  end
+  overrides = {
+    Comment = { italic = false },
+  },
 })
 ```


### PR DESCRIPTION
The suggested configuration didn't work for me, but simply overriding `italic = false` did.