### PR TITLE
make HTML highlighting more accurate to ayu examples

### DIFF
--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -363,20 +363,19 @@ local function set_groups()
     RenderMarkdownTableRow = { fg = colors.comment },
     RenderMarkdownTableFill = { fg = colors.comment },
 
-   -- HTML
-  	htmlTag = {fg = colors.entity},
-	htmlEndTag = {link = 'htmlTag'},
-    htmlTagName = {fg = colors.entity},
-	htmlArg = {fg = colors.func},
-	htmlTitle = {bold = true, fg = colors.fg},
-	htmlH1 = {link = 'htmlTitle'},
-	htmlH2 = {link = 'htmlTitle'},
-	htmlH3 = {link = 'htmlTitle'},
-	htmlH4 = {link = 'htmlTitle'},
-	htmlH5 = {link = 'htmlTitle'},
-	htmlH6 = {link = 'htmlTitle'},
- }
-
+    -- HTML
+    htmlTag = { fg = colors.entity },
+    htmlEndTag = { link = 'htmlTag' },
+    htmlTagName = { fg = colors.entity },
+    htmlArg = { fg = colors.func },
+    htmlTitle = { bold = true, fg = colors.fg },
+    htmlH1 = { link = 'htmlTitle' },
+    htmlH2 = { link = 'htmlTitle' },
+    htmlH3 = { link = 'htmlTitle' },
+    htmlH4 = { link = 'htmlTitle' },
+    htmlH5 = { link = 'htmlTitle' },
+    htmlH6 = { link = 'htmlTitle' },
+  }
 
   groups = vim.tbl_deep_extend('force', groups, type(config.overrides) == 'function' and config.overrides() or config.overrides)
 


### PR DESCRIPTION
I happen to write a lot of raw HTML, + I love Ayu, and while the automatic HTML highlighting was pretty, the "stock" Ayu (vscode style) HTML is a tad prettier IMO, so I manually added HTML syntax highlighting to reflect other distributions of Ayu. Examples below
<img width="1920" height="1047" alt="ayu dark HTML highlighting" src="https://github.com/user-attachments/assets/e8f30c1e-e9dd-4738-8459-a47e347eeafb" />
<img width="1920" height="1047" alt="ayu light HTML highlighting" src="https://github.com/user-attachments/assets/566a6d26-ca4e-4fe8-8a4d-323a0679a6b1" />
<img width="1920" height="1047" alt="ayu mirage HTML highlighting" src="https://github.com/user-attachments/assets/f0271487-3b9b-46f2-b37b-59a22ace2c12" />
