### PR TITLE
✨ (gitsigns): add GitSignsCurrentLineBlame highlight group

### DIFF
--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -375,6 +375,9 @@ local function set_groups()
     htmlH4 = { link = 'htmlTitle' },
     htmlH5 = { link = 'htmlTitle' },
     htmlH6 = { link = 'htmlTitle' },
+
+    -- Gitsigns.
+    GitSignsCurrentLineBlame = { fg = colors.gutter_normal, italic = true },
   }
 
   groups = vim.tbl_deep_extend('force', groups, type(config.overrides) == 'function' and config.overrides() or config.overrides)


### PR DESCRIPTION
Add a new highlight group for GitSignsCurrentLineBlame to improve visual distinction in the editor for the [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) plugin.