### PR TITLE
Adjust fg and bg of the MiniMap

### DIFF
--- a/lua/ayu/init.lua
+++ b/lua/ayu/init.lua
@@ -305,6 +305,7 @@ local function set_groups()
     MiniJump2dSpot = { fg = colors.keyword, bold = true, underline = true, nocombine = true },
     MiniJump2dSpotAhead = { fg = colors.entity, underline = true, nocombine = true },
     MiniJump2dSpotUnique = { fg = colors.tag, bold = true, underline = true, nocombine = true },
+    MiniMapNormal = { fg = colors.lsp_inlay_hint, bg = colors.panel_bg },
     MiniStarterItemPrefix = { fg = colors.accent },
     MiniStarterFooter = { link = 'Comment' },
     MiniStatuslineDevinfo = { fg = colors.fg, bg = colors.panel_border },


### PR DESCRIPTION
Because `MiniMapNormal` is linked to `NormalFloat`, which uses the same background color as `Normal`, the map has no visual distinction from the normal background leading to visual confusion. In addition, the foreground color is too bright leading to an unwarranted visual weight.

## Before
<img width="812" height="885" alt="Screenshot 2025-10-21 at 3 57 52 PM" src="https://github.com/user-attachments/assets/363ffbbb-1311-4afa-ae8c-0ec9d5543831" />

## After
Applied a darker background and lighter foreground to the map:
<img width="812" height="885" alt="Screenshot 2025-10-21 at 3 58 35 PM" src="https://github.com/user-attachments/assets/1f10af84-1021-45e5-871b-936bdf40b336" />
